### PR TITLE
Clang compile warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ project(NTIRPC C)
 
 # version numbers
 set(NTIRPC_MAJOR_VERSION 1)
-set(NTIRPC_MINOR_VERSION 3)
-set(NTIRPC_PATCH_LEVEL 1)
+set(NTIRPC_MINOR_VERSION 4)
+set(NTIRPC_PATCH_LEVEL 0)
 set(VERSION_COMMENT
   "Full-duplex and bi-directional ONC RPC on TCP."
 )

--- a/ntirpc/netconfig.h
+++ b/ntirpc/netconfig.h
@@ -71,6 +71,7 @@ typedef struct {
 #define NC_X25		"x25"
 #define NC_OSINET	"osinet"
 #define NC_GOSIP	"gosip"
+#define NC_VSOCK        "vsock"
 
 /*
  * nc_proto values
@@ -79,6 +80,7 @@ typedef struct {
 #define NC_TCP		"tcp"
 #define NC_UDP		"udp"
 #define NC_ICMP		"icmp"
+
 
 __BEGIN_DECLS
 extern void *setnetconfig(void);

--- a/ntirpc/rpc/nettype.h
+++ b/ntirpc/rpc/nettype.h
@@ -53,6 +53,7 @@
 #define	_RPC_DATAGRAM_N	6
 #define	_RPC_TCP	7
 #define	_RPC_UDP	8
+#define _RPC_VSOCK      9 /* XXX assignment */
 
 __BEGIN_DECLS
 extern void *__rpc_setconf(const char *);

--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -155,6 +155,7 @@ typedef struct svc_init_params {
 #define SVC_XPRT_FLAG_BLOCKED		0x0002
 #define SVC_XPRT_FLAG_DESTROYED		0x0020	/* SVC_DESTROY() was called */
 #define SVC_XPRT_FLAG_DESTROYING	0x0040	/* (*xp_destroy) was called */
+#define SVC_XPRT_FLAG_VSOCK             0x0080
 
 /* uint32_t instructions */
 #define SVC_XPRT_FLAG_LOCK		SVC_XPRT_FLAG_NONE
@@ -184,7 +185,9 @@ typedef enum xprt_type {
 	XPRT_TCP,
 	XPRT_TCP_RENDEZVOUS,
 	XPRT_SCTP,
-	XPRT_RDMA
+	XPRT_RDMA,
+	XPRT_VSOCK,
+	XPRT_VSOCK_RENDEZVOUS
 } xprt_type_t;
 
 enum xprt_stat {
@@ -748,6 +751,7 @@ __END_DECLS
 #define SVC_VC_CREATE_DISPOSE          0x0004	/* !bothways */
 #define SVC_VC_CREATE_XPRT_NOREG       0x0008
 #define SVC_VC_CREATE_LISTEN           0x0010
+#define SVC_VC_CREATE_VSOCK            0x0020
 
 __BEGIN_DECLS
 /*

--- a/src/authgss_hash.c
+++ b/src/authgss_hash.c
@@ -271,7 +271,8 @@ void authgss_ctx_gc_idle(void)
 
 		if (unlikely((authgss_hash_st.size > __svc_params->gss.max_gc)
 			     ||
-			     ((abs(axp->gen - gd->gen) >
+			     ((((axp->gen > gd->gen) ? 
+                                axp->gen - gd->gen : gd->gen - axp->gen) >
 			       __svc_params->gss.max_idle_gen))
 			     || (authgss_ctx_expired(gd)))) {
 

--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -217,6 +217,7 @@ NTIRPC_${NTIRPC_VERSION} {
     xdr_dplx_msg;
     xdr_enum;
     xdr_float;
+    xdr_free_null_stream;
     xdr_hyper;
     xdr_inrec_cksum;
     xdr_inrec_create;

--- a/src/mt_misc.c
+++ b/src/mt_misc.c
@@ -81,6 +81,7 @@ thread_key_t tcp_key = -1;
 thread_key_t udp_key = -1;
 thread_key_t nc_key = -1;
 thread_key_t rce_key = -1;
+thread_key_t vsock_key = -1;
 
 /* xprtlist (svc_generic.c) */
 pthread_mutex_t xprtlist_lock = MUTEX_INITIALIZER;

--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -51,6 +51,9 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <netdb.h>
+#ifdef RPC_VSOCK
+#include <linux/vm_sockets.h>
+#endif /* VSOCK */
 #include <netconfig.h>
 #include <err.h>
 #include <stdlib.h>
@@ -99,20 +102,22 @@ struct handle {
 	int nettype;
 };
 
-static const struct _rpcnettype {
+struct _rpcnettype {
 	const char *name;
 	const int type;
-} _rpctypelist[] = {
-	{
-	"netpath", _RPC_NETPATH}, {
-	"visible", _RPC_VISIBLE}, {
-	"circuit_v", _RPC_CIRCUIT_V}, {
-	"datagram_v", _RPC_DATAGRAM_V}, {
-	"circuit_n", _RPC_CIRCUIT_N}, {
-	"datagram_n", _RPC_DATAGRAM_N}, {
-	"tcp", _RPC_TCP}, {
-	"udp", _RPC_UDP}, {
-	0, _RPC_NONE}
+};
+
+static const struct _rpcnettype _rpctypelist[] = {
+	{"netpath", _RPC_NETPATH},
+	{"visible", _RPC_VISIBLE},
+	{"circuit_v", _RPC_CIRCUIT_V},
+	{"datagram_v", _RPC_DATAGRAM_V},
+	{"circuit_n", _RPC_CIRCUIT_N},
+	{"datagram_n", _RPC_DATAGRAM_N},
+	{"tcp", _RPC_TCP},
+	{"udp", _RPC_UDP},
+	{"vsock", _RPC_VSOCK},
+	{0, _RPC_NONE}
 };
 
 struct netid_af {
@@ -128,6 +133,9 @@ static const struct netid_af na_cvt[] = {
 	{"udp6", AF_INET6, IPPROTO_UDP},
 	{"tcp6", AF_INET6, IPPROTO_TCP},
 #endif
+#ifdef RPC_VSOCK
+	{"vsock", AF_VSOCK, PF_VSOCK},
+#endif /* VSOCK */
 	{"local", AF_LOCAL, 0}
 };
 
@@ -173,8 +181,13 @@ __rpc_get_t_size(int af, int proto, int size)
 	case IPPROTO_UDP:
 		defsize = UDPMSGSIZE;
 		break;
+#ifdef RPC_VSOCK
+	case PF_VSOCK:
+		defsize = 64 * 1024;	/* XXX */
+		break;
+#endif /* VSOCK */
 	default:
-		defsize = RPC_MAXDATASIZE;
+		defsize = RPC_MAXDATASIZE; /* 9000 */
 		break;
 	}
 	if (size == 0)
@@ -197,6 +210,11 @@ __rpc_get_a_size(int af)
 	case AF_INET6:
 		return sizeof(struct sockaddr_in6);
 #endif
+#ifdef RPC_VSOCK
+		/* Linux */
+	case AF_VSOCK:
+		return sizeof(struct sockaddr_vm);
+#endif /* VSOCK */
 	case AF_LOCAL:
 		return sizeof(struct sockaddr_un);
 	default:
@@ -251,8 +269,9 @@ __rpc_getconfip(const char *nettype)
 	char *netid;
 	char *netid_tcp = (char *)NULL;
 	char *netid_udp = (char *)NULL;
+	char *netid_vsock = (char *)NULL;
 	struct netconfig *dummy;
-	extern thread_key_t tcp_key, udp_key;
+	extern thread_key_t tcp_key, udp_key, vsock_key;
 	extern mutex_t tsd_lock;
 
 	if (tcp_key == -1) {
@@ -269,6 +288,13 @@ __rpc_getconfip(const char *nettype)
 		mutex_unlock(&tsd_lock);
 	}
 	netid_udp = (char *)thr_getspecific(udp_key);
+	if (vsock_key == -1) {
+		mutex_lock(&tsd_lock);
+		if (vsock_key == -1)
+			thr_keycreate(&vsock_key, free);
+		mutex_unlock(&tsd_lock);
+	}
+	netid_vsock = (char *)thr_getspecific(vsock_key);
 	if (!netid_udp && !netid_tcp) {
 		struct netconfig *nconf;
 		void *confighandle;
@@ -293,7 +319,15 @@ __rpc_getconfip(const char *nettype)
 					thr_setspecific(udp_key,
 							(void *)netid_udp);
 				}
-			}
+			} /* NC_INET || NC_INET6 */
+			if (strcmp(nconf->nc_protofmly, NC_VSOCK) == 0) {
+				if (netid_vsock == NULL) {
+					netid_vsock =
+						rpc_strdup(nconf->nc_netid);
+					thr_setspecific(vsock_key,
+							(void *)netid_vsock);
+				}
+			} /* VSOCK */
 		}
 		endnetconfig(confighandle);
 	}
@@ -301,6 +335,8 @@ __rpc_getconfip(const char *nettype)
 		netid = netid_udp;
 	else if (strcmp(nettype, "tcp") == 0)
 		netid = netid_tcp;
+	else if (strcmp(nettype, "vsock") == 0)
+		netid = netid_vsock;
 	else
 		return (NULL);
 	if ((netid == NULL) || (netid[0] == 0))
@@ -338,6 +374,7 @@ __rpc_setconf(const char *nettype)
 	case _RPC_DATAGRAM_V:
 	case _RPC_TCP:
 	case _RPC_UDP:
+	case _RPC_VSOCK:
 		handle->nhandle = setnetconfig();
 		if (!handle->nhandle) {
 			__warnx(TIRPC_DEBUG_FLAG_DEFAULT,
@@ -426,6 +463,14 @@ __rpc_getconf(void *vhandle)
 			    || strcmp(nconf->nc_proto, NC_UDP))
 				continue;
 			break;
+                case _RPC_VSOCK:
+			/* accept stream sockets only, there is no valid
+			 * proto (i.e., it must be "-") */
+			if ((nconf->nc_semantics != NC_TPI_COTS_ORD) ||
+				(strcmp(nconf->nc_protofmly, NC_VSOCK)) ||
+				(strcmp(nconf->nc_proto, NC_NOPROTO)))
+				continue;
+			break;
 		}
 		break;
 	}
@@ -505,9 +550,19 @@ __rpc_fd2sockinfo(int fd, struct __rpc_sockinfo *sip)
 
 	/* XXX */
 	if (ss.ss_family != AF_LOCAL) {
-		if (type == SOCK_STREAM)
-			proto = IPPROTO_TCP;
-		else if (type == SOCK_DGRAM)
+		if (type == SOCK_STREAM) {
+			switch (ss.ss_family) {
+			case PF_INET:
+			case PF_INET6:
+				proto = IPPROTO_TCP;
+				break;
+#ifdef RPC_VSOCK
+			case AF_VSOCK:
+				proto = PF_VSOCK;
+				break;
+#endif /* VSOCK */
+			}
+		} else if (type == SOCK_DGRAM)
 			proto = IPPROTO_UDP;
 		else
 			return 0;
@@ -677,6 +732,20 @@ __rpc_taddr2uaddr_af(int af, const struct netbuf *nbuf)
 		}
 		break;
 #endif
+#ifdef RPC_VSOCK
+	case AF_VSOCK:
+	{
+		struct sockaddr_vm *svm = nbuf->buf;
+		port = svm->svm_port;
+		if (sprintf
+			(ret, "%d.%u.%u", svm->svm_cid, ((u_int32_t)port) >> 8,
+				port & 0xff) < 0) {
+			mem_free(ret, 0);
+			return NULL;
+		}
+	}
+	break;
+#endif /* VSOCK */
 	case AF_LOCAL:
 		sun = nbuf->buf;
 		/* if (asprintf(&ret, "%.*s", (int)(sun->sun_len -
@@ -719,7 +788,7 @@ __rpc_uaddr2taddr_af(int af, const char *uaddr)
 
 	/*
 	 * AF_LOCAL addresses are expected to be absolute
-	 * pathnames, anything else will be AF_INET or AF_INET6.
+	 * pathnames.
 	 */
 	if (*addrstr != '/') {
 		p = strrchr(addrstr, '.');
@@ -775,6 +844,32 @@ __rpc_uaddr2taddr_af(int af, const char *uaddr)
 		ret->buf = sin6;
 		break;
 #endif
+#ifdef RPC_VSOCK
+	case AF_VSOCK:
+	{
+		struct sockaddr_in sin;
+		struct sockaddr_vm *svm;
+		svm = (struct sockaddr_vm *) mem_zalloc(
+			sizeof(struct sockaddr_vm));
+		if (svm == NULL)
+			goto out;
+		svm->svm_family = AF_VSOCK;
+		memset(&sin, 0, sizeof(sin));
+		sin.sin_family = AF_INET;
+		sin.sin_port = htons(port);
+		if (inet_pton(AF_INET, addrstr, &sin.sin_addr) <= 0) {
+			mem_free(svm, 0);
+			mem_free(ret, 0);
+			ret = NULL;
+			goto out;
+		}
+		svm->svm_cid = sin.sin_addr.s_addr;
+		svm->svm_port = port;
+		ret->maxlen = ret->len = sizeof(struct sockaddr_vm);
+		ret->buf = svm;
+	}
+	break;
+#endif /* VSOCK */
 	case AF_LOCAL:
 		sun = (struct sockaddr_un *)mem_zalloc(sizeof(*sun));
 		if (sun == NULL)
@@ -870,6 +965,9 @@ int __rpc_sockisbound(int fd)
 		struct sockaddr_in sin;
 		struct sockaddr_in6 sin6;
 		struct sockaddr_un usin;
+#ifdef RPC_VSOCK
+		struct sockaddr_vm svm;
+#endif /* VSOCK */
 	} u_addr;
 	socklen_t slen;
 
@@ -886,6 +984,11 @@ int __rpc_sockisbound(int fd)
 		memcpy(&u_addr.sin6, &ss, sizeof(u_addr.sin6));
 		return (u_addr.sin6.sin6_port != 0);
 #endif
+#ifdef RPC_VSOCK
+	case AF_VSOCK:
+		memcpy(&u_addr.svm, &ss, sizeof(u_addr.svm));
+		return (u_addr.svm.svm_port != 0);
+#endif /* VSOCK */
 	case AF_LOCAL:
 		/* XXX check this */
 		memcpy(&u_addr.usin, &ss, sizeof(u_addr.usin));

--- a/src/svc.c
+++ b/src/svc.c
@@ -52,6 +52,11 @@
 #include <sys/poll.h>
 #endif
 
+#include <sys/socket.h>
+#ifdef RPC_VSOCK
+#include <linux/vm_sockets.h>
+#endif /* VSOCK */
+
 #include <rpc/types.h>
 #include <misc/portable.h>
 #include <rpc/rpc.h>
@@ -294,6 +299,12 @@ __rpc_set_address(struct rpc_address *rpca, const struct sockaddr_storage *ss,
 		l = sl ? sl : sizeof(struct sockaddr);
 		memcpy(&rpca->ss, ss, l);
 		break;
+#ifdef RPC_VSOCK
+	case AF_VSOCK:
+		l = sl ? sl : sizeof(struct sockaddr_vm);
+		memcpy(&rpca->ss, ss, l);
+		break;
+#endif /* VSOCK */
 	default:
 		memset(&rpca->ss, 0xfe, sizeof(struct sockaddr_storage));
 		l = sl ? sl : sizeof(struct sockaddr);

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -37,6 +37,9 @@
  */
 #include <sys/cdefs.h>
 #include <sys/socket.h>
+#ifdef RPC_VSOCK
+#include <linux/vm_sockets.h>
+#endif /* VSOCK */
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/poll.h>
@@ -79,11 +82,12 @@
 int generic_read_vc(XDR *, void *, void *, int);
 int generic_write_vc(XDR *, void *, void *, int);
 
-static void svc_vc_rendezvous_ops(SVCXPRT *);
-static void svc_vc_ops(SVCXPRT *);
+static void svc_vc_rendezvous_ops(SVCXPRT *, u_int);
+static void svc_vc_ops(SVCXPRT *, u_int);
 static void svc_vc_override_ops(SVCXPRT *, SVCXPRT *);
 
 bool __svc_clean_idle2(int, bool);
+
 static SVCXPRT *makefd_xprt(int, u_int, u_int, bool *);
 
 extern pthread_mutex_t svc_ctr_lock;
@@ -126,6 +130,10 @@ svc_vc_ncreate2(int fd, u_int sendsize, u_int recvsize, u_int flags)
 
 	if (!__rpc_sockinfo2netid(&si, &netid))
 		return NULL;
+
+#ifdef RPC_VSOCK
+	flags |= (si.si_af == AF_VSOCK) ? SVC_VC_CREATE_VSOCK : 0;
+#endif /* VSOCK */
 
 	rdvs = mem_alloc(sizeof(struct cf_rendezvous));
 	if (rdvs == NULL) {
@@ -195,7 +203,7 @@ svc_vc_ncreate2(int fd, u_int sendsize, u_int recvsize, u_int flags)
 	}
 	xprt->xp_flags = SVC_XPRT_FLAG_NONE;
 	xprt->xp_refs = 1;
-	svc_vc_rendezvous_ops(xprt);
+	svc_vc_rendezvous_ops(xprt, flags);
 	xprt->xp_p1 = rdvs;
 	xprt->xp_p2 = xd;
 	xprt->xp_p5 = rec;
@@ -328,6 +336,7 @@ SVCXPRT *
 svc_fd_ncreate2(int fd, u_int sendsize, u_int recvsize, u_int flags)
 {
 	struct sockaddr_storage ss;
+	struct sockaddr *sa = (struct sockaddr *)(void *)&ss;
 	socklen_t slen;
 	SVCXPRT *xprt;
 	bool xprt_allocd;
@@ -339,7 +348,7 @@ svc_fd_ncreate2(int fd, u_int sendsize, u_int recvsize, u_int flags)
 		return (xprt);
 
 	slen = sizeof(struct sockaddr_storage);
-	if (getsockname(fd, (struct sockaddr *)(void *)&ss, &slen) < 0) {
+	if (getsockname(fd, sa, &slen) < 0) {
 		__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
 			"svc_fd_ncreate: could not retrieve local addr");
 		return (NULL);
@@ -363,7 +372,7 @@ svc_fd_ncreate2(int fd, u_int sendsize, u_int recvsize, u_int flags)
 }
 
 static SVCXPRT *
-makefd_xprt(int fd, u_int sendsz, u_int recvsz, bool *allocated)
+	makefd_xprt(int fd, u_int sendsz, u_int recvsz, bool *allocated)
 {
 	SVCXPRT *xprt = NULL;
 	struct x_vc_data *xd = NULL;
@@ -478,7 +487,12 @@ makefd_xprt(int fd, u_int sendsz, u_int recvsz, bool *allocated)
 	/* the SVCXPRT created in svc_vc_create accepts new connections
 	 * in its xp_recv op, the rendezvous_request method, but xprt is
 	 * a call channel */
-	svc_vc_ops(xprt);
+	u_int ops_flags =
+#ifdef RPC_VSOCK
+		(si.si_af == AF_VSOCK) ? SVC_VC_CREATE_VSOCK :
+#endif /* VSOCK */
+		0;
+	svc_vc_ops(xprt, ops_flags);
 
 	xd->sx.strm_stat = XPRT_IDLE;
 
@@ -1026,7 +1040,7 @@ svc_vc_unlock(SVCXPRT *xprt, uint32_t flags, const char *func, int line)
 }
 
 static void
-svc_vc_ops(SVCXPRT *xprt)
+svc_vc_ops(SVCXPRT *xprt, u_int flags)
 {
 	static struct xp_ops ops;
 
@@ -1034,6 +1048,11 @@ svc_vc_ops(SVCXPRT *xprt)
 	mutex_lock(&ops_lock);
 
 	xprt->xp_type = XPRT_TCP;
+	xprt->xp_type =
+#ifdef RPC_VSOCK
+		(flags & SVC_VC_CREATE_VSOCK) ? XPRT_VSOCK :
+#endif /* VSOCK */
+		XPRT_TCP;
 
 	if (ops.xp_recv == NULL) {
 		ops.xp_recv = svc_vc_recv;
@@ -1059,22 +1078,34 @@ svc_vc_override_ops(SVCXPRT *xprt, SVCXPRT *newxprt)
 {
 	if (xprt->xp_ops->xp_getreq)
 		newxprt->xp_ops->xp_getreq = xprt->xp_ops->xp_getreq;
+
 	if (xprt->xp_ops->xp_dispatch)
 		newxprt->xp_ops->xp_dispatch = xprt->xp_ops->xp_dispatch;
-	if (xprt->xp_ops->xp_recv_user_data)
-		newxprt->xp_ops->xp_recv_user_data = xprt->xp_ops->xp_recv_user_data;
-	if (xprt->xp_ops->xp_free_user_data)
-		newxprt->xp_ops->xp_free_user_data = xprt->xp_ops->xp_free_user_data;
+
+	if (xprt->xp_ops->xp_recv_user_data) {
+		newxprt->xp_ops->xp_recv_user_data =
+			xprt->xp_ops->xp_recv_user_data;
+	}
+	if (xprt->xp_ops->xp_free_user_data) {
+		newxprt->xp_ops->xp_free_user_data =
+			xprt->xp_ops->xp_free_user_data;
+	}
 }
 
 static void
-svc_vc_rendezvous_ops(SVCXPRT *xprt)
+svc_vc_rendezvous_ops(SVCXPRT *xprt, u_int flags)
 {
 	static struct xp_ops ops;
 	extern mutex_t ops_lock;
 
 	mutex_lock(&ops_lock);
-	xprt->xp_type = XPRT_TCP_RENDEZVOUS;
+
+	xprt->xp_type =
+#ifdef RPC_VSOCK
+		(flags & SVC_VC_CREATE_VSOCK) ? XPRT_VSOCK_RENDEZVOUS :
+#endif /* VSOCK */
+		XPRT_TCP_RENDEZVOUS;
+
 	if (ops.xp_recv == NULL) {
 		ops.xp_recv = rendezvous_request;
 		ops.xp_stat = rendezvous_stat;


### PR DESCRIPTION
...
[ 95%] Building C object src/CMakeFiles/ntirpc.dir/authgss_hash.c.o
cd /home/kkeithle/src/ntirpc-1.3.1/src && /usr/bin/clang  -DHAVE_CONFIG_H -DINET6 -DPORTMAP -D_GNU_SOURCE -Dntirpc_EXPORTS -fPIC -fPIC -I/home/kkeithle/src/ntirpc-1.3.1/ntirpc -I/home/kkeithle/src/ntirpc-1.3.1    -o CMakeFiles/ntirpc.dir/authgss_hash.c.o   -c /home/kkeithle/src/ntirpc-1.3.1/src/authgss_hash.c
/home/kkeithle/src/ntirpc-1.3.1/src/authgss_hash.c:274:11: warning: taking the
      absolute value of unsigned type 'unsigned int' has no effect
      [-Wabsolute-value]
                             ((abs(axp->gen - gd->gen) >
                               ^
/home/kkeithle/src/ntirpc-1.3.1/ntirpc/intrinsic.h:32:42: note: expanded from
      macro 'unlikely'
# define unlikely(x)  __builtin_expect(!!(x), 0)

```
                                     ^
```

/home/kkeithle/src/ntirpc-1.3.1/src/authgss_hash.c:274:11: note: remove the call
      to 'abs' since unsigned values cannot be negative
                             ((abs(axp->gen - gd->gen) >
                               ^~~
/home/kkeithle/src/ntirpc-1.3.1/ntirpc/intrinsic.h:32:42: note: expanded from
      macro 'unlikely'
# define unlikely(x)  __builtin_expect(!!(x), 0)

```
                                     ^
```

1 warning generated.
...
