### PR TITLE
xdr x_data: cast to char* before pointer arithmetic

### DIFF
--- a/ntirpc/rpc/types.h
+++ b/ntirpc/rpc/types.h
@@ -218,7 +218,7 @@ static inline char *
 mem_strdup_(const char *s, const char *file, int line, const char *function)
 {
 	size_t l = strlen(s) + 1;
-	char *t = __ntirpc_pkg_params.malloc_(l, file, line, function);
+	char *t = (char *) __ntirpc_pkg_params.malloc_(l, file, line, function);
 
 	memcpy(t, s, l);
 	return (t);

--- a/ntirpc/rpc/xdr.h
+++ b/ntirpc/rpc/xdr.h
@@ -248,8 +248,8 @@ xdr_getlong(XDR *xdrs, long *lp)
 	void *future;
 
 	if (!(xdrs->x_flags & XDR_FLAG_VIO)
-	 || unlikely((future = xdrs->x_data + sizeof(uint32_t))
-						> xdrs->x_v.vio_tail)) {
+		|| unlikely((future = ((char *) xdrs->x_data) +
+				sizeof(uint32_t)) > xdrs->x_v.vio_tail)) {
 		return (*xdrs->x_ops->x_getlong)(xdrs, lp);
 	}
 	*lp = (long)ntohl(*((uint32_t *) (xdrs->x_data)));
@@ -263,8 +263,8 @@ xdr_putlong(XDR *xdrs, const long *lp)
 	void *future;
 
 	if (!(xdrs->x_flags & XDR_FLAG_VIO)
-	 || unlikely((future = xdrs->x_data + sizeof(uint32_t))
-						> xdrs->x_v.vio_wrap)) {
+		|| unlikely((future = ((char *) xdrs->x_data) +
+				sizeof(uint32_t)) > xdrs->x_v.vio_wrap)) {
 		return (*xdrs->x_ops->x_putlong)(xdrs, lp);
 	}
 	*((int32_t *) (xdrs->x_data)) = (int32_t) htonl((int32_t) (*lp));
@@ -407,8 +407,8 @@ xdr_getuint32(XDR *xdrs, uint32_t *ip)
 	void *future;
 
 	if (!(xdrs->x_flags & XDR_FLAG_VIO)
-	 || unlikely((future = xdrs->x_data + sizeof(uint32_t))
-						> xdrs->x_v.vio_tail)) {
+		|| unlikely((future = ((char *) xdrs->x_data) +
+				sizeof(uint32_t)) > xdrs->x_v.vio_tail)) {
 		long l;
 
 		if (!(*xdrs->x_ops->x_getlong)(xdrs, &l))
@@ -427,8 +427,8 @@ xdr_putuint32(XDR *xdrs, uint32_t *ip)
 	void *future;
 
 	if (!(xdrs->x_flags & XDR_FLAG_VIO)
-	 || unlikely((future = xdrs->x_data + sizeof(uint32_t))
-						> xdrs->x_v.vio_wrap)) {
+		|| unlikely((future = ((char *) xdrs->x_data) +
+				sizeof(uint32_t)) > xdrs->x_v.vio_wrap)) {
 		long l = (long)*ip;
 
 		return (*xdrs->x_ops->x_putlong)(xdrs, &l);
@@ -462,8 +462,8 @@ xdr_getuint16(XDR *xdrs, uint16_t *ip)
 	void *future;
 
 	if (!(xdrs->x_flags & XDR_FLAG_VIO)
-	 || unlikely((future = xdrs->x_data + sizeof(uint32_t))
-						> xdrs->x_v.vio_tail)) {
+		|| unlikely((future = ((char *) xdrs->x_data) +
+				sizeof(uint32_t)) > xdrs->x_v.vio_tail)) {
 		long l;
 
 		if (!(*xdrs->x_ops->x_getlong)(xdrs, &l))
@@ -482,8 +482,8 @@ xdr_putuint16(XDR *xdrs, uint32_t uint16v)
 	void *future;
 
 	if (!(xdrs->x_flags & XDR_FLAG_VIO)
-	 || unlikely((future = xdrs->x_data + sizeof(uint32_t))
-						> xdrs->x_v.vio_wrap)) {
+		|| unlikely((future = ((char *) xdrs->x_data) +
+				sizeof(uint32_t)) > xdrs->x_v.vio_wrap)) {
 		long l = (long)uint16v;
 
 		return (*xdrs->x_ops->x_putlong)(xdrs, &l);
@@ -518,8 +518,8 @@ xdr_getuint8(XDR *xdrs, uint8_t *ip)
 	void *future;
 
 	if (!(xdrs->x_flags & XDR_FLAG_VIO)
-	 || unlikely((future = xdrs->x_data + sizeof(uint32_t))
-						> xdrs->x_v.vio_tail)) {
+		|| unlikely((future = ((char *) xdrs->x_data) +
+				sizeof(uint32_t)) > xdrs->x_v.vio_tail)) {
 		long l;
 
 		if (!(*xdrs->x_ops->x_getlong)(xdrs, &l))
@@ -538,8 +538,8 @@ xdr_putuint8(XDR *xdrs, uint32_t uint8v)
 	void *future;
 
 	if (!(xdrs->x_flags & XDR_FLAG_VIO)
-	 || unlikely((future = xdrs->x_data + sizeof(uint32_t))
-						> xdrs->x_v.vio_wrap)) {
+		|| unlikely((future = ((char *) xdrs->x_data) +
+				sizeof(uint32_t)) > xdrs->x_v.vio_wrap)) {
 		long l = (long)uint8v;
 
 		return (*xdrs->x_ops->x_putlong)(xdrs, &l);


### PR DESCRIPTION
Required for C++ inclusion.

Signed-off-by: Matt Benjamin mbenjamin@redhat.com
