### PR TITLE
A bunch of CMake-related fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ configure_file(
 configure_file(
   "${NTIRPC_BASE_DIR}/libntirpc.pc.in.cmake"
   "${PROJECT_BINARY_DIR}/libntirpc.pc"
+  @ONLY
 )
 
 ########### install files ###############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,14 +24,20 @@ set(NTIRPC_VERSION
   "${NTIRPC_MAJOR_VERSION}.${NTIRPC_MINOR_VERSION}.${NTIRPC_PATCH_LEVEL}")
 
 # Install destination, if built standalone
-get_property(USE_LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-if (USE_LIB64)
-	set(LIB_INSTALL_DIR lib64 CACHE PATH
-		"Specify name of libdir inside install path")
-else (USE_LIB64)
-	set(LIB_INSTALL_DIR lib CACHE PATH
-		"Specify name of libdir inside install path")
-endif (USE_LIB64)
+include(GNUInstallDirs OPTIONAL)
+# support old CMake without GNUInstallDirs
+if (NOT CMAKE_INSTALL_LIBDIR)
+	get_property(USE_LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
+	if (USE_LIB64)
+		set(LIB_INSTALL_DIR lib64 CACHE PATH
+			"Specify name of libdir inside install path")
+	else (USE_LIB64)
+		set(LIB_INSTALL_DIR lib CACHE PATH
+			"Specify name of libdir inside install path")
+	endif (USE_LIB64)
+else (NOT CMAKE_INSTALL_LIBDIR)
+	set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+endif (NOT CMAKE_INSTALL_LIBDIR)
 
 set(SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES})
 

--- a/libntirpc.pc.in.cmake
+++ b/libntirpc.pc.in.cmake
@@ -1,11 +1,11 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_PREFIX@/@LIB_INSTALL_DIR@
+includedir=@CMAKE_INSTALL_PREFIX@/include
 
 Name: libntirpc
 Description: New Transport Independent RPC Library
 Requires:
 Version: @NTIRPC_VERSION@
-Libs: -L@libdir@ -lintirpc
-Cflags: -I@includedir@/ntirpc
+Libs: -L${libdir} -lintirpc
+Cflags: -I${includedir}/ntirpc


### PR DESCRIPTION
To begin with, the pkgconfig data file should now be actually usable. Secondly, use the GNUInstallDirs (available if the CMake version is recent enough) to determine the value of LIB_INSTALL_DIR - it is more portable (e.g. supports Debian-style lib/<arch> in addition to lib/lib32/lib64), it handles 32-bit builds on 64-bit systems better (something I ran into while trying to write a ntirpc ebuild for Gentoo), and it sets a bunch of other variables which may come in handy in the future.
